### PR TITLE
Update minibsdiff.c comments which shows how to compile it

### DIFF
--- a/minibsdiff.c
+++ b/minibsdiff.c
@@ -32,7 +32,7 @@
  *
  * Compile with:
  *
- *   $ cc -Wall -std=c99 -O2 minibsdiff.c bsdiff.c bspatch.c
+ *   $ cc -Wall -std=c99 -O2 minibsdiff.c
  *
  * Usage:
  *


### PR DESCRIPTION
Fix comment on how to build minibsdiff.c into a standalone program. Since it does #include C files we get duplicate symbols linking problem with the original compile line in that comment.

```
$ cc -Wall -std=c99 -O2 minibsdiff.c bsdiff.c bspatch.c
minibsdiff.c:148:65: warning: format specifies type 'long' but the argument has type 'off_t' (aka 'long long') [-Wformat]
  printf("sizeof(delta('%s', '%s')) = %ld bytes\n", oldf, newf, patchsz);
                                      ~~~                       ^~~~~~~
                                      %lld
1 warning generated.
duplicate symbol _bsdiff_patchsize_max in:
    /var/folders/qz/cb1zd5756hnd2tykv7z5sn_j8408d8/T/minibsdiff-79ffd9.o
    /var/folders/qz/cb1zd5756hnd2tykv7z5sn_j8408d8/T/bsdiff-013fa0.o
duplicate symbol _bsdiff in:
    /var/folders/qz/cb1zd5756hnd2tykv7z5sn_j8408d8/T/minibsdiff-79ffd9.o
    /var/folders/qz/cb1zd5756hnd2tykv7z5sn_j8408d8/T/bsdiff-013fa0.o
duplicate symbol _bspatch_valid_header in:
    /var/folders/qz/cb1zd5756hnd2tykv7z5sn_j8408d8/T/minibsdiff-79ffd9.o
    /var/folders/qz/cb1zd5756hnd2tykv7z5sn_j8408d8/T/bspatch-ec29af.o
duplicate symbol _bspatch in:
    /var/folders/qz/cb1zd5756hnd2tykv7z5sn_j8408d8/T/minibsdiff-79ffd9.o
    /var/folders/qz/cb1zd5756hnd2tykv7z5sn_j8408d8/T/bspatch-ec29af.o
duplicate symbol _bspatch_newsize in:
    /var/folders/qz/cb1zd5756hnd2tykv7z5sn_j8408d8/T/minibsdiff-79ffd9.o
    /var/folders/qz/cb1zd5756hnd2tykv7z5sn_j8408d8/T/bspatch-ec29af.o
ld: 5 duplicate symbols for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
